### PR TITLE
Add a 'default' profile to be used when no other profile is selected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,14 @@ comment = "Profile names can contain whitespaces. Quote on command line..."
 [profile.rogcat]
 comment = "Only tag \"rogcat\""
 tag = ["^rogcat$"]
+
+[profile.default]
+comment = "Default profile"
 ```
 
 To check your setup, run `rogcat profiles --list` and select a profile for a run by passing the `-p/--profile` option.
+
+You can create a special profile named `default` which will be used when no other profile is selected on the command line.
 
 ## Usage
 

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -28,6 +28,8 @@ use std::{
 };
 use toml::from_str;
 
+const DEFAULT_PROFILE_NAME: &str = "default";
+
 /// Profile definition with filters and misc
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Profile {
@@ -69,6 +71,9 @@ pub fn from_args(args: &ArgMatches) -> Result<Profile, Error> {
                 .ok_or_else(|| format_err!("Unknown profile {}", n))?
                 .clone();
             expand(n, &mut profile, &profiles)?;
+        } else if let Some(default_profile) = profiles.get(DEFAULT_PROFILE_NAME) {
+            profile = default_profile.clone();
+            expand(DEFAULT_PROFILE_NAME, &mut profile, &profiles)?;
         }
 
         Ok(profile)


### PR DESCRIPTION
This may be a breaking change if somebody have already created a profile named 'default'.