### PR TITLE
Flush after writing formatted records

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -337,6 +337,7 @@ impl<T: Write> Sink for FormatSink<T> {
         self.sink
             .write_all(self.format.fmt_record(&record)?.as_bytes())?;
         self.sink.write_all(&[b'\n'])?;
+        self.sink.flush()?;
         Ok(AsyncSink::Ready)
     }
 


### PR DESCRIPTION
When filtering live adb logs with formatted output, occasionally the last match is missing (as it's still buffered, but not yet printed).